### PR TITLE
added initializer guide to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,98 @@ A page in Spina has many Page parts. By default these page parts can be one of t
 
 These are the building blocks of your view templates. You can have an unlimited number of page parts in a page. We prefer to keep the number of parts to a minimum so that managing your pages won't become too complex.
 
+Spina uses an initializer to create the basic building blocks of your page. There are three steps to add a new building block or page part to your app:
+1.	Set up a new page part in the initializer
+2.	Set the new initializer into a view template
+3.	Add it to the view
+
+
+#### Create a new page part
+When you install Spina, you will see the folling in config/initializers/themes/default.rb
+
+```
+module Spina
+  module DefaultTheme
+    include ::ActiveSupport::Configurable
+
+    config_accessor :title, :page_parts, :view_templates, :layout_parts, :custom_pages, :plugins, :structures
+
+    self.title = "Default theme"
+
+    self.page_parts = [{
+      name: 'content',
+      title: 'Content',
+      page_partable_type: "Spina::Text"
+    }]
+
+    self.structures = []
+    self.layout_parts = []
+    self.custom_pages = []
+    self.plugins = []
+
+    self.view_templates = {
+      'homepage' => {
+        title: 'Homepage',
+        page_parts: ['content']
+      },
+      'show' => {
+        title: 'Default',
+        description: 'A simple page',
+        usage: 'Use for your content',
+        page_parts: ['content']
+      }
+    }
+
+    self.custom_pages = [
+      { name: 'homepage', title: 'Homepage', deletable: false, view_template: 'homepage' }
+    ]
+  end
+end
+```
+
+Right now, the default theme is applying a title to the page, with a simple text div below it. Go to '/admin' on your app and have a look. Edit the textbox and go to preview the page.
+
+Spina represents each building block of your page, called a 'page part,' as a hash inside the page_parts array. If we look at the default setup we can see there is one hash inside the array representing the one textbox we see on our page.
+
+Let's say I wanted to add another text box below this called 'portfolio.' First I would add another hash to the `self.page_parts` array like so:
+
+```
+self.page_parts = [
+  { name: 'content', title: 'Content', page_partable_type: "Spina::Text" },
+  { name: 'portfolio', title: 'Portfolio', page_partable_type: "Spina::Text" } # added this second hash
+]
+```
+
+#### Add it to the view template
+
+Now, we need to update the `self.view_templates` hash next. These view templates provide customization for the different views you might want. For example, you may have a 'blog' view or an 'about' view which add different page parts. For this example we will add the portfolio part into the 'Default' view template.
+
+```
+self.view_templates = {
+  'homepage' => {
+    title: 'Homepage',
+    page_parts: ['content']
+  },
+  'show' => {
+    title: 'Default',
+    description: 'A simple page',
+    usage: 'Use for your content',
+    page_parts: ['content', 'portfolio'] # added 'portfolio' here.
+  }
+}
+```
+#### Add it to the view
+
+Finally, let's go to views/default/pages/show.html.erb and add the following:
+```
+<h1><%= @page.title %></h1>
+
+<%= @page.content(:content).try(:html_safe) %>
+<%= @page.content(:portfolio).try(:html_safe) %> # added this line
+```
+
+We have successfully added another textbox! Restart your server and load up the admin section again. You should see another text box below the content box.
+
 ## Layout parts
 
 Sometimes you need editable content that's not specific to a view template but to your theme as a whole. You can use the following parts in your layout.


### PR DESCRIPTION
I was struggling with how to set up the page layout initializer. I wrote a guide to hopefully help anyone else. Let me know what you think. I've copied the guide below for quick reference. 

insert after Page parts header:

Spina uses an initializer to create the basic building blocks of your page. There are three steps to add a new building block or page part to your app:
1.	Set up a new page part in the initializer
2.	Set the new initializer into a view template
3.	Add it to the view


#### Create a new page part
When you install Spina, you will see the folling in config/initializers/themes/default.rb

```
module Spina
  module DefaultTheme
    include ::ActiveSupport::Configurable

    config_accessor :title, :page_parts, :view_templates, :layout_parts, :custom_pages, :plugins, :structures

    self.title = "Default theme"

    self.page_parts = [{
      name: 'content',
      title: 'Content',
      page_partable_type: "Spina::Text"
    }]

    self.structures = []
    self.layout_parts = []
    self.custom_pages = []
    self.plugins = []

    self.view_templates = {
      'homepage' => {
        title: 'Homepage',
        page_parts: ['content']
      },
      'show' => {
        title: 'Default',
        description: 'A simple page',
        usage: 'Use for your content',
        page_parts: ['content']
      }
    }

    self.custom_pages = [
      { name: 'homepage', title: 'Homepage', deletable: false, view_template: 'homepage' }
    ]
  end
end
```

Right now, the default theme is applying a title to the page, with a simple text div below it. Go to '/admin' on your app and have a look. Edit the textbox and go to preview the page.

Spina represents each building block of your page, called a 'page part,' as a hash inside the page_parts array. If we look at the default setup we can see there is one hash inside the array representing the one textbox we see on our page.

Let's say I wanted to add another text box below this called 'portfolio.' First I would add another hash to the `self.page_parts` array like so:

```
self.page_parts = [
  { name: 'content', title: 'Content', page_partable_type: "Spina::Text" },
  { name: 'portfolio', title: 'Portfolio', page_partable_type: "Spina::Text" } # added this second hash
]
```

#### Add it to the view template

Now, we need to update the `self.view_templates` hash next. These view templates provide customization for the different views you might want. For example, you may have a 'blog' view or an 'about' view which add different page parts. For this example we will add the portfolio part into the 'Default' view template.

```
self.view_templates = {
  'homepage' => {
    title: 'Homepage',
    page_parts: ['content']
  },
  'show' => {
    title: 'Default',
    description: 'A simple page',
    usage: 'Use for your content',
    page_parts: ['content', 'portfolio'] # added 'portfolio' here.
  }
}
```
#### Add it to the view

Finally, let's go to views/default/pages/show.html.erb and add the following:
```
<h1><%= @page.title %></h1>

<%= @page.content(:content).try(:html_safe) %>
<%= @page.content(:portfolio).try(:html_safe) %> # added this line
```

We have successfully added another textbox! Restart your server and load up the admin section again. You should see another text box below the content box.
