### PR TITLE
Fixed javascript error when there are no layout parts on selected theme #27

### DIFF
--- a/app/assets/javascripts/spina/admin/account.js.coffee
+++ b/app/assets/javascripts/spina/admin/account.js.coffee
@@ -12,4 +12,5 @@ $(document).on 'change', '.account-theme select', ->
 show_layout_parts = (layout_parts) ->
   $('tr.layout-part').hide()
   for layout_part in layout_parts
-    $('tr.layout-part[data-name=' + layout_part + ']').show()
+    if layout_part
+      $('tr.layout-part[data-name=' + layout_part + ']').show()


### PR DESCRIPTION
Selecting themes with no layout-parts specified will throw a js error
Fix #27 