### PR TITLE
S3 Support

### DIFF
--- a/app/uploaders/spina/file_uploader.rb
+++ b/app/uploaders/spina/file_uploader.rb
@@ -3,7 +3,11 @@ module Spina
   class FileUploader < CarrierWave::Uploader::Base
 
     def store_dir
-      "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      if Engine.config.storage == :s3
+        "#{mounted_as}/#{model.id}"
+      else
+        "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      end
     end
 
   end

--- a/app/uploaders/spina/file_uploader.rb
+++ b/app/uploaders/spina/file_uploader.rb
@@ -2,55 +2,9 @@
 module Spina
   class FileUploader < CarrierWave::Uploader::Base
 
-    # Include RMagick or MiniMagick support:
-    # include CarrierWave::RMagick
-    # include CarrierWave::MiniMagick
-
-    # Include the Sprockets helpers for Rails 3.1+ asset pipeline compatibility:
-    # include Sprockets::Helpers::RailsHelper
-    # include Sprockets::Helpers::IsolatedHelper
-
-    # Choose what kind of storage to use for this uploader:
-    storage :file
-    # storage :fog
-
-    # Override the directory where uploaded files will be stored.
-    # This is a sensible default for uploaders that are meant to be mounted:
     def store_dir
       "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
     end
-
-    # Provide a default URL as a default if there hasn't been a file uploaded:
-    # def default_url
-    #   # For Rails 3.1+ asset pipeline compatibility:
-    #   # asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-    #
-    #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-    # end
-
-    # Process files as they are uploaded:
-    # process :scale => [200, 300]
-    #
-    # def scale(width, height)
-    #   # do something
-    # end
-
-    # Create different versions of your uploaded files:
-    # version :thumb do
-    #   process :scale => [50, 50]
-    # end
-
-    # Add a white list of extensions which are allowed to be uploaded.
-    # For images you might use something like this:
-    # def extension_white_list
-    #   %w(jpg jpeg gif png)
-    # end
-
-    # Override the filename of the uploaded files:
-    # Avoid using model.id or version_name here, see uploader/store.rb for details.
-    # def filename
-    #   "something.jpg" if original_filename
-    # end
 
   end
 end

--- a/app/uploaders/spina/logo_uploader.rb
+++ b/app/uploaders/spina/logo_uploader.rb
@@ -3,50 +3,17 @@
 module Spina
   class LogoUploader < CarrierWave::Uploader::Base
 
-    # Include RMagick or MiniMagick support:
-    # include CarrierWave::RMagick
     include CarrierWave::MiniMagick
 
-    # Choose what kind of storage to use for this uploader:
-    storage :file
-    # storage :fog
-
-    # Override the directory where uploaded files will be stored.
-    # This is a sensible default for uploaders that are meant to be mounted:
     def store_dir
       "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
     end
 
-    # Provide a default URL as a default if there hasn't been a file uploaded:
-    # def default_url
-    #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-    # end
-
-    # Process files as they are uploaded:
-    # process :scale => [200, 300]
-    #
-    # def scale(width, height)
-    #   # do something
-    # end
-
-    # Create different versions of your uploaded files:
-    # version :thumb do
-    #   process :scale => [50, 50]
-    # end
-
     process resize_to_fit: [300, 300]
 
-    # Add a white list of extensions which are allowed to be uploaded.
-    # For images you might use something like this:
     def extension_white_list
       %w(jpg jpeg gif png)
     end
-
-    # Override the filename of the uploaded files:
-    # Avoid using model.id or version_name here, see uploader/store.rb for details.
-    # def filename
-    #   "something.jpg" if original_filename
-    # end
 
   end
 end

--- a/app/uploaders/spina/logo_uploader.rb
+++ b/app/uploaders/spina/logo_uploader.rb
@@ -6,7 +6,11 @@ module Spina
     include CarrierWave::MiniMagick
 
     def store_dir
-      "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      if Engine.config.storage == :s3
+        "#{mounted_as}/#{model.id}"
+      else
+        "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      end
     end
 
     process resize_to_fit: [300, 300]

--- a/app/uploaders/spina/photo_uploader.rb
+++ b/app/uploaders/spina/photo_uploader.rb
@@ -5,7 +5,11 @@ module Spina
     include CarrierWave::MiniMagick
 
     def store_dir
-      "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      if Engine.config.storage == :s3
+        "#{mounted_as}/#{model.id}"
+      else
+        "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      end
     end
 
     version :image do

--- a/app/uploaders/spina/photo_uploader.rb
+++ b/app/uploaders/spina/photo_uploader.rb
@@ -2,20 +2,8 @@
 module Spina
   class PhotoUploader < CarrierWave::Uploader::Base
 
-    # Include RMagick or MiniMagick support:
-    # include CarrierWave::RMagick
     include CarrierWave::MiniMagick
 
-    # Include the Sprockets helpers for Rails 3.1+ asset pipeline compatibility:
-    # include Sprockets::Helpers::RailsHelper
-    # include Sprockets::Helpers::IsolatedHelper
-
-    # Choose what kind of storage to use for this uploader:
-    storage :file
-    # storage :fog
-
-    # Override the directory where uploaded files will be stored.
-    # This is a sensible default for uploaders that are meant to be mounted:
     def store_dir
       "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
     end
@@ -24,7 +12,6 @@ module Spina
       process resize_to_fit: [800, 800], if: :too_large?
     end
 
-    # Create different versions of your uploaded files:
     version :thumb do
       process resize_to_fill: [240, 135]
     end
@@ -33,10 +20,9 @@ module Spina
       new_file.size > 120 * 1000
     end
 
-    # Add a white list of extensions which are allowed to be uploaded.
-    # For images you might use something like this:
     def extension_white_list
       %w(jpg jpeg gif png)
     end
+
   end
 end

--- a/lib/generators/spina/templates/spina.rb
+++ b/lib/generators/spina/templates/spina.rb
@@ -1,3 +1,10 @@
 Spina::Engine.configure do
   config.NEGATIVE_CAPTCHA_SECRET = '<%= SecureRandom.hex(64) %>'
+
+  # If you want to use s3 to store uploads
+  # config.storage = :s3
+  # config.aws_region = "eu-west-1"
+  # config.aws_access_key_id = "abc123"
+  # config.aws_secret_key = "abc123"
+  # config.s3_bucket = "mybucket"
 end

--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -26,6 +26,27 @@ module Spina
       end
     end
 
+    initializer "spina.configure_carrierwave" do
+      CarrierWave.configure do |cfg|
+        if Engine.config.storage == :s3
+          cfg.storage = :fog
+          cfg.fog_credentials = {
+            :provider               => 'AWS',
+            :region                 => Engine.config.aws_region,
+            :aws_access_key_id      => Engine.config.aws_access_key_id,
+            :aws_secret_access_key  => Engine.config.aws_secret_key
+          }
+          cfg.fog_directory  = Engine.config.s3_bucket
+          cfg.fog_public     = true
+          cfg.fog_attributes = {'Cache-Control'=>'max-age=315576000'}
+        else
+          cfg.storage = :file
+        end
+
+        cfg.enable_processing = !Rails.env.test?
+      end
+    end
+
     config.to_prepare &method(:require_decorators).to_proc
     config.autoload_paths += %W( #{config.root}/lib )
   end

--- a/test/dummy/config/initializers/spina.rb
+++ b/test/dummy/config/initializers/spina.rb
@@ -1,3 +1,4 @@
 Spina::Engine.configure do
   config.NEGATIVE_CAPTCHA_SECRET = '445e0c9c0cee31f783754bc174661052d1236850da8f5f5ba5e11cbfa56cbaa8bce9260df75feaa56da91949ee4204fefac41c35b3e4f5e0d3e395b00c87781a'
+  config.storage = :file
 end


### PR DESCRIPTION
This pull request adds support for S3 and cleans up comments in the carrierwave uploader files.

To enable S3, uncomment the extra config options and edit as required.