### PR TITLE
fix storage check

### DIFF
--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -28,7 +28,7 @@ module Spina
 
     initializer "spina.configure_carrierwave" do
       CarrierWave.configure do |cfg|
-        if Engine.config.storage == :s3
+        if Engine.config.try(:storage) == :s3
           cfg.storage = :fog
           cfg.fog_credentials = {
             provider: 'AWS',


### PR DESCRIPTION
On current git, master branch, fix error if storage is not installed:

```
$ rails g spina:install
/home/rs/.rvm/gems/ruby-2.0.0-p643/gems/railties-4.2.1/lib/rails/railtie/configuration.rb:95:in `method_missing': undefined method `storage' for #<Rails::Engine::Configuration:0x00000003c06360> (NoMethodError)
	from /home/rs/Work/hack_app/gems/Spina/lib/spina/engine.rb:31:in `block (2 levels) in <class:Engine>'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/carrierwave-0.10.0/lib/carrierwave/uploader/configuration.rb:118:in `configure'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/carrierwave-0.10.0/lib/carrierwave.rb:14:in `configure'
	from /home/rs/Work/hack_app/gems/Spina/lib/spina/engine.rb:30:in `block in <class:Engine>'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/railties-4.2.1/lib/rails/initializable.rb:30:in `instance_exec'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/railties-4.2.1/lib/rails/initializable.rb:30:in `run'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/railties-4.2.1/lib/rails/initializable.rb:55:in `block in run_initializers'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/2.0.0/tsort.rb:150:in `block in tsort_each'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/2.0.0/tsort.rb:183:in `block (2 levels) in each_strongly_connected_component'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/2.0.0/tsort.rb:219:in `each_strongly_connected_component_from'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/2.0.0/tsort.rb:182:in `block in each_strongly_connected_component'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/2.0.0/tsort.rb:180:in `each'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/2.0.0/tsort.rb:180:in `each_strongly_connected_component'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/2.0.0/tsort.rb:148:in `tsort_each'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/railties-4.2.1/lib/rails/initializable.rb:54:in `run_initializers'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/railties-4.2.1/lib/rails/application.rb:352:in `initialize!'
	from /home/rs/Work/hack_app/config/environment.rb:5:in `<top (required)>'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/activesupport-4.2.1/lib/active_support/dependencies.rb:274:in `require'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/activesupport-4.2.1/lib/active_support/dependencies.rb:274:in `block in require'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/activesupport-4.2.1/lib/active_support/dependencies.rb:240:in `load_dependency'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/activesupport-4.2.1/lib/active_support/dependencies.rb:274:in `require'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/spring-1.3.6/lib/spring/application.rb:92:in `preload'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/spring-1.3.6/lib/spring/application.rb:143:in `serve'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/spring-1.3.6/lib/spring/application.rb:131:in `block in run'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/spring-1.3.6/lib/spring/application.rb:125:in `loop'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/spring-1.3.6/lib/spring/application.rb:125:in `run'
	from /home/rs/.rvm/gems/ruby-2.0.0-p643/gems/spring-1.3.6/lib/spring/application/boot.rb:18:in `<top (required)>'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/rs/.rvm/rubies/ruby-2.0.0-p643/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from -e:1:in `<main>'

```
Related to #32 