### PR TITLE
Added live scope to pages for sitemaps#show

### DIFF
--- a/app/controllers/spina/sitemaps_controller.rb
+++ b/app/controllers/spina/sitemaps_controller.rb
@@ -1,7 +1,7 @@
 module Spina
   class SitemapsController < ApplicationController
     def show
-      @pages = Page.sorted
+      @pages = Page.live.sorted
     end
   end
 end


### PR DESCRIPTION
I noticed that the sitemap was also displaying pages marked as drafts. I think it should only display pages that are not drafts and active.