### PR TITLE
fix #69 - better error when no storage solution is configured; add file storage as an option for storage (albeit not one recommended for production.)

### DIFF
--- a/app/uploaders/spina/default_store_uploader.rb
+++ b/app/uploaders/spina/default_store_uploader.rb
@@ -2,10 +2,13 @@ module Spina
   class DefaultStoreUploader < CarrierWave::Uploader::Base
 
     def store_dir
-      if Engine.config.try(:storage) == :s3
+      case Engine.config.try(:storage)
+      when :s3
         "#{mounted_as}/#{model.class.to_s.underscore}/#{model.id}"
-      else
+      when :file
         "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      else
+        raise NotImplementedError, "Please set your storage preferences in config/initializers/spina.rb"
       end
     end
   end

--- a/lib/generators/spina/templates/spina.rb
+++ b/lib/generators/spina/templates/spina.rb
@@ -1,10 +1,29 @@
 Spina::Engine.configure do
   config.NEGATIVE_CAPTCHA_SECRET = '<%= SecureRandom.hex(64) %>'
 
-  # If you want to use s3 to store uploads
+  # Important Note
+  # ==============
+  #
+  # You MUST restart your server before changes to this file
+  # will take effect.
+  #
+  # Storage Options
+  # ===============
+  #
+  # Please specify how you want to store photos, your logo, and
+  # other files. We use CarrierWave for storage. See
+  # https://github.com/denkGroot/Spina/tree/master/app/uploaders/spina
+  #
+  # If you want to use s3 to store uploads (recommended)
+  #
   # config.storage = :s3
   # config.aws_region = "eu-west-1"
   # config.aws_access_key_id = "abc123"
   # config.aws_secret_key = "abc123"
   # config.s3_bucket = "mybucket"
+  # If you want to store your files localy (not recommended for
+  # production, in large part because it's more difficult to ensure
+  # that files are backed up in sync with your database):
+  #
+  # config.storage = :file
 end


### PR DESCRIPTION
I would be happy to add tests to this PR if someone will work with me on getting your test suite set up. I'm not used to testing Rails Engines.

```
jw@logopolis:/projects/open/spina$ bundle exec rake test
rake aborted!
ExecJS::RuntimeUnavailable: Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
/var/lib/gems/1.9.1/gems/execjs-2.5.2/lib/execjs/runtimes.rb:48:in `autodetect'
```