### PR TITLE
split admin/pages/_form into multiple files to allow smaller view overrides

### DIFF
--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -15,7 +15,7 @@ module Spina
       def new
         @page = Page.new
         if current_theme.new_page_templates.any? { |template| template[0] == params[:view_template] }
-          @page.view_template = params[:view_template] 
+          @page.view_template = params[:view_template]
         end
         add_breadcrumb I18n.t('spina.pages.new')
         @page_parts = current_theme.config.page_parts.map { |page_part| @page.page_part(page_part) }
@@ -36,6 +36,7 @@ module Spina
         @page = Page.find(params[:id])
         add_breadcrumb @page.title
         @page_parts = current_theme.config.page_parts.map { |page_part| @page.page_part(page_part) }
+        @tabs = %w{page_content page_seo advanced}
       end
 
       def update

--- a/app/views/spina/admin/pages/_form.html.haml
+++ b/app/views/spina/admin/pages/_form.html.haml
@@ -2,69 +2,8 @@
   - content_for :notification_alert do
     = error_explanation!(@page)
 
-  #page_content.tab-content.active
-    .table-container
-      %table.table.table-form
-        %tr
-          %td
-            = Spina::Page.human_attribute_name :title
-          %td
-            = f.text_field :title, placeholder: Spina::Page.human_attribute_name(:title_placeholder)
-
-        = f.fields_for :page_parts, @page_parts.sort { |a,b| a.position(current_theme) <=> b.position(current_theme) } do |page_part_form|
-          %tr.page-part{data: {name: page_part_form.object.name}}
-            = render partial: "spina/admin/page_partables/#{page_part_form.object.page_partable_type.demodulize.underscore}_form", object: page_part_form
-
-  #page_seo.tab-content
-    .table-container
-      %table.table.table-form
-        %tr
-          %td
-            = Spina::Page.human_attribute_name :seo_title
-          %td
-            = f.text_field :seo_title, placeholder: Spina::Page.human_attribute_name(:seo_title_placeholder)
-
-        %tr
-          %td
-            = Spina::Page.human_attribute_name :description
-            %small= Spina::Page.human_attribute_name :description_description
-          %td
-            = f.text_field :description, placeholder: Spina::Page.human_attribute_name(:description_placeholder)
-
-  #advanced.tab-content
-    .table-container
-      %table.table.table-form
-        %tr
-          %td
-            = Spina::Page.human_attribute_name :draft
-            %small= Spina::Page.human_attribute_name :draft_description
-          %td
-            = f.check_box :draft, data: {switch: true}
-        %tr
-          %td
-            = Spina::Page.human_attribute_name :skip_to_first_child
-            %small= Spina::Page.human_attribute_name :skip_to_first_child_description
-          %td
-            = f.check_box :skip_to_first_child, data: {switch: true}
-        %tr
-          %td
-            = Spina::Page.human_attribute_name :show_in_menu
-            %small= Spina::Page.human_attribute_name :show_in_menu_description
-          %td
-            = f.check_box :show_in_menu, data: {switch: true}
-        %tr{style: ('border-bottom: none' if @page.custom_page?)}
-          %td
-            = Spina::Page.human_attribute_name :menu_title
-          %td
-            = f.text_field :menu_title, placeholder: Spina::Page.human_attribute_name(:show_in_menu_placeholder)
-
-        %tr{style: ('display: none' if @page.custom_page?)}
-          %td
-            = Spina::Page.human_attribute_name :view_template
-          %td
-            .select-dropdown.page-template{data: {page_parts: current_theme.config.view_templates[@page.view_template || "show"][:page_parts]}}
-              - options = options_for_select(current_theme.config.view_templates.map { |template| [template[1][:title], template[0], {'data-page-parts' => template[1][:page_parts]}] }, @page.view_template)
-              = f.select :view_template, options
+  - @tabs.each do |tab|
+    = render "spina/admin/pages/form_#{tab}", f: f
 
   %button.button.button-primary{type: 'submit'}
     = icon('check')

--- a/app/views/spina/admin/pages/_form_advanced.html.haml
+++ b/app/views/spina/admin/pages/_form_advanced.html.haml
@@ -1,0 +1,34 @@
+#advanced.tab-content
+  .table-container
+    %table.table.table-form
+      %tr
+        %td
+          = Spina::Page.human_attribute_name :draft
+          %small= Spina::Page.human_attribute_name :draft_description
+        %td
+          = f.check_box :draft, data: {switch: true}
+      %tr
+        %td
+          = Spina::Page.human_attribute_name :skip_to_first_child
+          %small= Spina::Page.human_attribute_name :skip_to_first_child_description
+        %td
+          = f.check_box :skip_to_first_child, data: {switch: true}
+      %tr
+        %td
+          = Spina::Page.human_attribute_name :show_in_menu
+          %small= Spina::Page.human_attribute_name :show_in_menu_description
+        %td
+          = f.check_box :show_in_menu, data: {switch: true}
+      %tr{style: ('border-bottom: none' if @page.custom_page?)}
+        %td
+          = Spina::Page.human_attribute_name :menu_title
+        %td
+          = f.text_field :menu_title, placeholder: Spina::Page.human_attribute_name(:show_in_menu_placeholder)
+
+      %tr{style: ('display: none' if @page.custom_page?)}
+        %td
+          = Spina::Page.human_attribute_name :view_template
+        %td
+          .select-dropdown.page-template{data: {page_parts: current_theme.config.view_templates[@page.view_template || "show"][:page_parts]}}
+            - options = options_for_select(current_theme.config.view_templates.map { |template| [template[1][:title], template[0], {'data-page-parts' => template[1][:page_parts]}] }, @page.view_template)
+            = f.select :view_template, options

--- a/app/views/spina/admin/pages/_form_page_content.html.haml
+++ b/app/views/spina/admin/pages/_form_page_content.html.haml
@@ -1,0 +1,12 @@
+#page_content.tab-content.active
+  .table-container
+    %table.table.table-form
+      %tr
+        %td
+          = Spina::Page.human_attribute_name :title
+        %td
+          = f.text_field :title, placeholder: Spina::Page.human_attribute_name(:title_placeholder)
+
+      = f.fields_for :page_parts, @page_parts.sort { |a,b| a.position(current_theme) <=> b.position(current_theme) } do |page_part_form|
+        %tr.page-part{data: {name: page_part_form.object.name}}
+          = render partial: "spina/admin/page_partables/#{page_part_form.object.page_partable_type.demodulize.underscore}_form", object: page_part_form

--- a/app/views/spina/admin/pages/_form_page_seo.html.haml
+++ b/app/views/spina/admin/pages/_form_page_seo.html.haml
@@ -1,0 +1,15 @@
+#page_seo.tab-content
+  .table-container
+    %table.table.table-form
+      %tr
+        %td
+          = Spina::Page.human_attribute_name :seo_title
+        %td
+          = f.text_field :seo_title, placeholder: Spina::Page.human_attribute_name(:seo_title_placeholder)
+
+      %tr
+        %td
+          = Spina::Page.human_attribute_name :description
+          %small= Spina::Page.human_attribute_name :description_description
+        %td
+          = f.text_field :description, placeholder: Spina::Page.human_attribute_name(:description_placeholder)

--- a/app/views/spina/admin/pages/edit.html.haml
+++ b/app/views/spina/admin/pages/edit.html.haml
@@ -1,11 +1,8 @@
 - content_for(:tertiary_navigation) do
   %nav.tabs
     %ul
-      %li.active
-        = link_to t('spina.pages.page_content'), "#page_content"
-      %li
-        = link_to t('spina.pages.page_seo'), "#page_seo"
-      %li
-        = link_to t('spina.pages.advanced'), "#advanced"
+      - @tabs.each_with_index do |tab, i|
+        %li{class: (i==0 ? 'active' : '')}
+          = link_to t("spina.pages.#{tab}"), "##{tab}"
 
 = render 'form'


### PR DESCRIPTION
When adding extra properties to page I was having to override the entire `spina/admin/pages/_form` and I thought it would be better to override the view for only part of the form.

Since the page form is already split into tabs this seemed like a good place to split up the form and additional make the number of tabs extendable (@tabs in the edit action might be better configured elsewhere?)

What do you think?