### PR TITLE
structure_form.object.page_partable can be nil

### DIFF
--- a/app/views/spina/admin/page_partables/_structure_form.html.haml
+++ b/app/views/spina/admin/page_partables/_structure_form.html.haml
@@ -9,11 +9,12 @@
       %label= structure_form.object.title
 
       %ul
-        - structure_form.object.page_partable.structure_items.sorted_by_structure.each_with_index do |structure_item, index|
-          %li{class: ('active' if index == 0), data: {structure_item_id: structure_item.id}}
-            = link_to "#structure_form_pane_#{structure_item.id}" do
-              %i.icon.icon-bars.sortable-handle
-              = structure_item.structure_parts.first.try(:structure_partable).try(:content)
+        - unless structure_form.object.page_partable.nil?
+          - structure_form.object.page_partable.structure_items.sorted_by_structure.each_with_index do |structure_item, index|
+            %li{class: ('active' if index == 0), data: {structure_item_id: structure_item.id}}
+              = link_to "#structure_form_pane_#{structure_item.id}" do
+                %i.icon.icon-bars.sortable-handle
+                = structure_item.structure_parts.first.try(:structure_partable).try(:content)
 
 
       = structure_form.fields_for :page_partable do |form|


### PR DESCRIPTION
When rendering edit `structure_form.object.page_partable` can be nil, it seems to be happening when another view_template has a structure that this view_template isn't using.

Checking for nil solves the issue for me.