### PR TITLE
add textfield to edit link_url on spina_page

### DIFF
--- a/app/views/spina/admin/pages/_form_advanced.html.haml
+++ b/app/views/spina/admin/pages/_form_advanced.html.haml
@@ -15,6 +15,12 @@
           = f.check_box :skip_to_first_child, data: {switch: true}
       %tr
         %td
+          = Spina::Page.human_attribute_name :link_url
+          %small= Spina::Page.human_attribute_name :link_url_description
+        %td
+          = f.text_field :link_url, placeholder: Spina::Page.human_attribute_name(:link_url_placeholder)
+      %tr
+        %td
           = Spina::Page.human_attribute_name :show_in_menu
           %small= Spina::Page.human_attribute_name :show_in_menu_description
         %td

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,10 +115,10 @@ en:
 
   activerecord:
     models:
-      spina/page: 
+      spina/page:
         one: Page
         other: Pages
-      spina/user: 
+      spina/user:
         one: User
         other: Users
       spina/photo:
@@ -175,6 +175,9 @@ en:
         draft_description: Great for when your page is not quite finished
         skip_to_first_child: Forward
         skip_to_first_child_description: Forward to first child page
+        link_url: Page Redirect
+        link_url_description: Forward to URL
+        link_url_placeholder: e.g. http://www.example.com/
         show_in_menu: Show in navigation
         show_in_menu_description: "When turned off this page won't be shown in your navigation"
         menu_title: Navigation title


### PR DESCRIPTION
Expose link_url to editing in advanced page options. Was already present in the model and working, just couldn't edit it.

I've added the english translation for the link_url, link_url_description and link_url_placeholder.