### PR TITLE
Prevent namespace conflict

### DIFF
--- a/app/controllers/spina/inquiries_controller.rb
+++ b/app/controllers/spina/inquiries_controller.rb
@@ -1,5 +1,5 @@
 module Spina
-  class InquiriesController < ApplicationController
+  class InquiriesController < Spina::ApplicationController
 
     before_filter :setup_negative_captcha, only: [:create]
 

--- a/app/controllers/spina/pages_controller.rb
+++ b/app/controllers/spina/pages_controller.rb
@@ -1,5 +1,5 @@
 module Spina
-  class PagesController < ApplicationController
+  class PagesController < Spina::ApplicationController
     before_action :rewrite_page, only: [:show]
     before_action :current_user_can_view_page?, except: [:robots]
 

--- a/app/controllers/spina/sitemaps_controller.rb
+++ b/app/controllers/spina/sitemaps_controller.rb
@@ -1,5 +1,5 @@
 module Spina
-  class SitemapsController < ApplicationController
+  class SitemapsController < Spina::ApplicationController
     def show
       @pages = Page.live.sorted
     end


### PR DESCRIPTION
ApplicationController exists as ::ApplicationController and
Spina::Application controller.  Specifying Spina::Application
controller for inheritance ensures the right class will be the parent.