### PR TITLE
ActiveRecord::RecordNotFound for missing pages

### DIFF
--- a/app/controllers/spina/pages_controller.rb
+++ b/app/controllers/spina/pages_controller.rb
@@ -27,7 +27,7 @@ module Spina
       end
 
       def page
-        @page ||= (action_name == 'homepage') ? Page.find_by(name: 'homepage') : Page.find_by(materialized_path: "/" + params[:id])
+        @page ||= (action_name == 'homepage') ? Page.find_by!(name: 'homepage') : Page.find_by!(materialized_path: "/" + params[:id])
       end
       helper_method :page
 


### PR DESCRIPTION
Currently a missing page errors in `show` on `should_skip_to_first_child?` because page is nil.
`find_by!` will raise ActiveRecord::RecordNotFound and halt the action and cause a 404