### PR TITLE
Don't resave all pages on account update

### DIFF
--- a/app/models/spina/account.rb
+++ b/app/models/spina/account.rb
@@ -54,16 +54,16 @@ module Spina
 
     def find_or_create_custom_pages(theme)
       theme.config.custom_pages.each do |page|
-        Page.where(name: page[:name]).first_or_create(title: page[:title]).update_attributes(view_template: page[:view_template], deletable: page[:deletable])
+        Page.where(name: page[:name]).first_or_create(title: page[:title]).update_columns(view_template: page[:view_template], deletable: page[:deletable])
       end
     end
 
     def deactivate_unused_view_templates(theme)
-      Page.where.not(view_template: theme.config.view_templates.keys).update_all(active: false)
+      Page.where(active: true).where.not(view_template: theme.config.view_templates.keys).update_all(active: false)
     end
 
     def activate_used_view_templates(theme)
-      Page.where(view_template: theme.config.view_templates.keys).update_all(active: true)
+      Page.where(active: false).where(view_template: theme.config.view_templates.keys).update_all(active: true)
     end
 
   end


### PR DESCRIPTION
This is a performance fix for saving the current_account i.e 'Save preferences' on `http://cosmos.dev/admin/account/edit`

1. Change to `update_columns` as we're only changing the template and deletable and to prevent callbacks which in my case cause  ~ 80% of pages to save because they're child of custom pages

2. only deactivate and activate pages which need it, this stops all pages from re saving