### PR TITLE
Avoid class name collision with main app

### DIFF
--- a/app/controllers/spina/admin/admin_controller.rb
+++ b/app/controllers/spina/admin/admin_controller.rb
@@ -1,7 +1,7 @@
 module Spina
   module Admin
     class AdminController < ApplicationController
-      
+
       before_filter :authorize_user
       before_filter :new_messages
 
@@ -21,9 +21,9 @@ module Spina
         @current_account ||= Account.first
       end
       helper_method :current_account
-      
+
       def current_user
-        @current_user ||= User.where(id: session[:user_id]).first if session[:user_id]
+        @current_user ||= Spina::User.where(id: session[:user_id]).first if session[:user_id]
       end
       helper_method :current_user
 

--- a/app/controllers/spina/application_controller.rb
+++ b/app/controllers/spina/application_controller.rb
@@ -16,7 +16,7 @@ module Spina
     end
 
     def current_user
-      @current_user ||= User.where(id: session[:user_id]).first if session[:user_id]
+      @current_user ||= Spina::User.where(id: session[:user_id]).first if session[:user_id]
     end
 
     def current_account


### PR DESCRIPTION
Specifying the spina namespace is required when the main application has its own auth layer (devise). Maybe we should namespace every spina model to ensure strict isolation. [Forem](https://github.com/rubysherpas/forem) does it but [Spree](https://github.com/spree/spree) does not always specify it. What's you opinion on this issue ?