### PR TITLE
Fix image upload url with altered backend path

### DIFF
--- a/app/assets/javascripts/spina/admin/spina.trix.js.coffee.erb
+++ b/app/assets/javascripts/spina/admin/spina.trix.js.coffee.erb
@@ -30,7 +30,7 @@ Trix.config.blockAttributes = $.extend Trix.config.blockAttributes, {
 class Spina.TrixAttachment
   @photoSelect: (e) ->
     editor_id = $(this).closest('trix-toolbar').data('editor-id')
-    $.get("/admin/photos/wysihtml5_select/#{editor_id}")
+    $.get("<%= Spina::Engine.routes.url_helpers.wysihtml5_select_admin_photos_path('') %>/#{editor_id}")
 
   @photoInsert: (e, url) ->
     length = this.editor.getDocument().toString().length


### PR DESCRIPTION
When you change `config.backend_path`, image handling in RTE will stop working, because it has a hardcoded path with `admin` as a `backend_path`. This is the fix for that.