### PR TITLE
Fix parent page selection #114

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -90,6 +90,11 @@ module Spina
       theme.view_templates.find { |template| template[:name] == view_template_name }
     end
 
+    def possible_parents
+      parents = self.class.active.sorted
+      new_record? ? parents : parents - subtree
+    end
+
     private
 
     def rewrite_rule
@@ -109,7 +114,7 @@ module Spina
         name == 'homepage' ? '' : "#{url_title}"
       else
         ancestors.collect(&:url_title).append(url_title).join('/')
-      end      
+      end
     end
 
     def ancestry_is_nil

--- a/app/views/spina/admin/pages/_form_advanced.html.haml
+++ b/app/views/spina/admin/pages/_form_advanced.html.haml
@@ -41,7 +41,7 @@
 
       %tr{style: ('display: none' if @page.custom_page?)}
         %td
-          = Spina::Page.human_attribute_name :ancestry
+          = Spina::Page.human_attribute_name :parent_id
         %td
           .select-dropdown.ancestry
-            = f.select :ancestry, options_from_collection_for_select(Spina::Page.active.sorted.roots, 'id', 'menu_title', @page.ancestry.to_i), include_blank: Spina::Page.human_attribute_name(:no_parent)
+            = f.select :parent_id, options_from_collection_for_select(@page.possible_parents, 'id', 'menu_title', @page.parent_id), include_blank: Spina::Page.human_attribute_name(:no_parent)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,7 +160,7 @@ en:
         menu_title: Navigation title
         menu_title_placeholder: Leave empty to use the page title
         view_template: Page template
-        ancestry: Parent page
+        parent_id: Parent page
         no_parent: No parent
 
       spina/user:


### PR DESCRIPTION
Hi!
In addition to this fix, we probably should activate ancestry's depth caching and restrict presented pages to those that have a lower depth than the configured `max_page_depth`. Which would involve instructions for migrating because users would have to [rebuild the depth cache](https://github.com/stefankroes/ancestry#integrity-checking-and-restoration).

```ruby
def possible_parents
  parents = self.class.active.sorted.to_depth(Spina.config.max_page_depth - 1)
  new_record? ? parents : parents - subtree
end
```