### PR TITLE
Fix urls in menu with non-standard backend_path

### DIFF
--- a/app/controllers/spina/pages_controller.rb
+++ b/app/controllers/spina/pages_controller.rb
@@ -34,9 +34,14 @@ module Spina
       end
 
       def page
-        @page ||= (action_name == 'homepage') ? Page.find_by!(name: 'homepage') : Page.with_translations(I18n.locale).find_by!(materialized_path: request.path) || Page.with_translations(I18n.default_locale).find_by!(materialized_path: request.path)
+        @page ||= (action_name == 'homepage') ? Page.find_by!(name: 'homepage') : Page.with_translations(I18n.locale).find_by!(materialized_path: materialized_path) || Page.with_translations(I18n.default_locale).find_by!(materialized_path: request.path)
       end
       helper_method :page
+
+      def materialized_path
+        segments = ['/', params[:locale], params[:id]].compact
+        File.join(*segments)
+      end
 
       def current_user_can_view_page?
         raise ActiveRecord::RecordNotFound unless page.live? || current_user.present?

--- a/app/presenters/spina/pages/menu_presenter.rb
+++ b/app/presenters/spina/pages/menu_presenter.rb
@@ -60,8 +60,9 @@ module Spina
 
       def render_menu_item(menu_item, index, menu_items_length)
         content_tag(list_item_tag, class: menu_item_css(menu_item[0], index, menu_items_length)) do
+          path = File.join(Spina::Engine.routes.url_helpers.root_path, menu_item[0].materialized_path)
           buffer = ActiveSupport::SafeBuffer.new
-          buffer << link_to(menu_item[0].menu_title, menu_item[0].materialized_path)
+          buffer << link_to(menu_item[0].menu_title, path)
           buffer << render_list_wrapper(menu_item[1])
           buffer
         end


### PR DESCRIPTION
This fixes issue similar to https://github.com/denkGroot/Spina/pull/132: When Spina is mounted not on `/`, links in navigation do not reflect it and lead to incorrect location (for example to `/test-page` instead of `/content/test-page` when `mount Spina::Engine => '/content/'`).