### PR TITLE
Remove rewrite_page

### DIFF
--- a/app/controllers/spina/pages_controller.rb
+++ b/app/controllers/spina/pages_controller.rb
@@ -27,14 +27,13 @@ module Spina
       end
 
       def rewrite_page
-        unless page.present?
-          @rule = RewriteRule.find_by(old_path: "/" + params[:id])
-          redirect_to @rule.new_path, status: :moved_permanently if @rule.present?
+        if page.nil? && rule = RewriteRule.find_by(old_path: "/" + params[:id])
+          redirect_to rule.new_path, status: :moved_permanently
         end
       end
 
       def page_by_locale(locale)
-        Page.with_translations(locale).find_by!(materialized_path: spina_request_path)
+        Page.with_translations(locale).find_by(materialized_path: spina_request_path)
       end
 
       def page


### PR DESCRIPTION
@Bramjetten  Please review

The function is not necessary. Because when the page can't be found out, it will raise an error shows the record not found

The method will catch it
rescue_from ActiveRecord::RecordNotFound, with: :render_404