### PR TITLE
Constrain robots route to txt

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Spina::Engine.routes.draw do
   resource :sitemap
 
   # Robots.txt
-  get '/robots', to: 'pages#robots', format: :txt
+  get '/robots', to: 'pages#robots', constraints: { format: 'txt' }
 
   # Frontend
   root to: "pages#homepage"


### PR DESCRIPTION
Limit route to only robots.txt instead of robots, robots.html, robots.json etc

We have a page about robots which errors because the pages#robots action doesn't render html for obvious reasons.

The constraint makes it possible to have a robots.txt and a /robots page
