### PR TITLE
update page template views to use the text page part instead of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Finally, let's go to `views/default/pages/show.html.erb` and add the following:
 ```ruby
 <h1><%= @page.title %></h1>
 
-<%= @page.content(:content).try(:html_safe) %>
+<%= @page.content(:text).try(:html_safe) %>
 <%= @page.content(:portfolio).try(:html_safe) %> # added this line
 ```
 

--- a/lib/generators/spina/templates/app/views/default/pages/homepage.html.haml
+++ b/lib/generators/spina/templates/app/views/default/pages/homepage.html.haml
@@ -1,2 +1,2 @@
 %h1= @page.title
-= @page.content(:content).try(:html_safe)
+= @page.content(:text).try(:html_safe)

--- a/lib/generators/spina/templates/app/views/default/pages/show.html.haml
+++ b/lib/generators/spina/templates/app/views/default/pages/show.html.haml
@@ -1,3 +1,3 @@
 %h1= @page.title
-= @page.content(:content).try(:html_safe)
+= @page.content(:text).try(:html_safe)
 

--- a/lib/generators/spina/templates/app/views/demo/pages/homepage.html.haml
+++ b/lib/generators/spina/templates/app/views/demo/pages/homepage.html.haml
@@ -1,2 +1,2 @@
 %h1= @page.title
-= @page.content(:content).try(:html_safe)
+= @page.content(:text).try(:html_safe)

--- a/lib/generators/spina/templates/app/views/demo/pages/show.html.haml
+++ b/lib/generators/spina/templates/app/views/demo/pages/show.html.haml
@@ -1,3 +1,3 @@
 %h1= @page.title
-= @page.content(:content).try(:html_safe)
+= @page.content(:text).try(:html_safe)
 

--- a/test/dummy/app/views/default/pages/homepage.html.haml
+++ b/test/dummy/app/views/default/pages/homepage.html.haml
@@ -1,2 +1,2 @@
 %h1= @page.title
-= @page.content(:content).try(:html_safe)
+= @page.content(:text).try(:html_safe)

--- a/test/dummy/app/views/default/pages/show.html.haml
+++ b/test/dummy/app/views/default/pages/show.html.haml
@@ -1,3 +1,3 @@
 %h1= @page.title
-= @page.content(:content).try(:html_safe)
+= @page.content(:text).try(:html_safe)
 

--- a/test/dummy/app/views/demo/pages/homepage.html.haml
+++ b/test/dummy/app/views/demo/pages/homepage.html.haml
@@ -1,2 +1,2 @@
 %h1= @page.title
-= @page.content(:content).try(:html_safe)
+= @page.content(:text).try(:html_safe)

--- a/test/dummy/app/views/demo/pages/show.html.haml
+++ b/test/dummy/app/views/demo/pages/show.html.haml
@@ -1,3 +1,3 @@
 %h1= @page.title
-= @page.content(:content).try(:html_safe)
+= @page.content(:text).try(:html_safe)
 


### PR DESCRIPTION
Fix for https://github.com/denkGroot/Spina/issues/169 

Default and Demo config files use `text` not `content`