### PR TITLE
add linkedin and instagram inputs to settings

### DIFF
--- a/app/controllers/spina/admin/accounts_controller.rb
+++ b/app/controllers/spina/admin/accounts_controller.rb
@@ -35,8 +35,9 @@ module Spina
       def account_params
         params.require(:account).permit(:address, :city, :email, :logo, :name, :phone,
                                         :postal_code, :preferences, :google_analytics,
-                                        :google_site_verification, :facebook, :twitter, :google_plus,
-                                        :kvk_identifier, :theme, :vat_identifier, :robots_allowed,
+                                        :google_site_verification, :facebook, :twitter,
+                                        :google_plus, :linkedin, :instagram, :kvk_identifier,
+                                        :theme, :vat_identifier, :robots_allowed,
                                         layout_parts_attributes:
                                           [:id, :layout_partable_type, :layout_partable_id,
                                             :name, :title, :position, :content, :page_id,

--- a/app/models/spina/account.rb
+++ b/app/models/spina/account.rb
@@ -36,7 +36,8 @@ module Spina
       end
     end
 
-    serialized_attr_accessor :google_analytics, :google_site_verification, :facebook, :twitter, :google_plus, :theme
+    serialized_attr_accessor  :google_analytics, :google_site_verification, :facebook, :twitter,
+                              :google_plus, :linkedin, :instagram, :theme
 
     private
 

--- a/app/views/spina/admin/accounts/social.html.haml
+++ b/app/views/spina/admin/accounts/social.html.haml
@@ -26,3 +26,15 @@
           = Spina::Account.human_attribute_name(:google_plus)
         .horizontal-form-content
           = f.text_field :google_plus, placeholder: Spina::Account.human_attribute_name(:google_plus)
+
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Account.human_attribute_name(:linkedin)
+        .horizontal-form-content
+          = f.text_field :linkedin, placeholder: Spina::Account.human_attribute_name(:linkedin)
+
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Account.human_attribute_name(:instagram)
+        .horizontal-form-content
+          = f.text_field :instagram, placeholder: Spina::Account.human_attribute_name(:instagram)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -135,6 +135,8 @@ de:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Erstellt am

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -139,6 +139,8 @@ en:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Created at

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -135,6 +135,8 @@ es:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Creado en

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -131,6 +131,8 @@ fr:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Créer à

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -135,6 +135,8 @@ it:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Creato il

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -139,6 +139,8 @@ nl:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Aangemaakt op

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -135,6 +135,8 @@ pt-BR:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Criado em

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -143,6 +143,8 @@ ru:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Создан в

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -135,6 +135,8 @@ tr:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: Oluşturulma zamanı

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -152,6 +152,8 @@ zh-CN:
         facebook: Facebook
         twitter: Twitter
         google_plus: Google+
+        linkedin: LinkedIn
+        instagram: Instagram
 
       spina/attachment:
         created_at: 创建于


### PR DESCRIPTION
### Add Instagram and LinkedIn

Most businesses have more than just Facebook and Twitter so it's beneficial to have control over the other popular channels in the CMS too.
