### PR TITLE
ensures position is created on a new structure item

### DIFF
--- a/app/models/spina/structure_item.rb
+++ b/app/models/spina/structure_item.rb
@@ -1,14 +1,20 @@
 module Spina
   class StructureItem < ApplicationRecord
+    before_validation :ensure_position
     belongs_to :structure
     has_many :structure_parts, dependent: :destroy
 
     scope :sorted_by_structure, -> { order('position') }
 
+    validates_presence_of :position
     accepts_nested_attributes_for :structure_parts, allow_destroy: true
 
     def content(structure_part)
       structure_parts.find_by(name: structure_part).try(:content)
+    end
+
+    def ensure_position
+      self.position ||= Time.now.to_i
     end
   end
 end

--- a/test/models/spina/structure_item_test.rb
+++ b/test/models/spina/structure_item_test.rb
@@ -20,5 +20,10 @@ module Spina
       assert_equal nil, @structure_item_2.content(@structure_part_1.name)
     end
 
+    test 'structure_item_1 position' do
+      assert_equal nil, @structure_item_1.position
+      @structure_item_1.save!
+      refute_nil @structure_item_1.position
+    end
   end
 end


### PR DESCRIPTION
Fixes the second of @DanBrooker 's issue in #167 where position can be nil on create