### PR TITLE
New Turbolinks 5 syntax.

### DIFF
--- a/app/views/spina/admin/shared/_primary_navigation.html.haml
+++ b/app/views/spina/admin/shared/_primary_navigation.html.haml
@@ -55,5 +55,5 @@
             =t 'spina.main_menu'
 
     %li.bottom
-      = link_to spina.admin_logout_path, data: {no_turbolink: true} do
+      = link_to spina.admin_logout_path, data: {turbolinks: false} do
         = icon('power-off')


### PR DESCRIPTION
Disable turbolinks in link using new Turbolinks 5 syntax.