### PR TITLE
add missing translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,6 +68,7 @@ en:
       insert_photo: Insert image
       link: "URL of your image:"
       cannot_be_created: "Image could not be processed:"
+      upload_image: "Upload an image"
 
     wysiwyg:
       paragraph: Paragraph


### PR DESCRIPTION
This was triggering a translation missing error when visiting the route: `http://localhost:3000/admin/photos`