### PR TITLE
Fix globalize warnings

### DIFF
--- a/db/migrate/2_create_spina_translation_tables.rb
+++ b/db/migrate/2_create_spina_translation_tables.rb
@@ -1,13 +1,32 @@
 class CreateSpinaTranslationTables < ActiveRecord::Migration
   def up
-    Spina::Page.create_translation_table! title: :string, menu_title: :string, description: :string, seo_title: :string, materialized_path: :string
-    Spina::Text.create_translation_table! content: :text
-    Spina::Line.create_translation_table! content: :string
+    Spina::Page.create_translation_table!({
+      title: :string,
+      menu_title: :string,
+      description: :string,
+      seo_title: :string,
+      materialized_path: :string
+    }, {
+      migrate_data: true,
+      remove_source_columns: true
+    })
+    Spina::Text.create_translation_table!({
+      content: :text
+    }, {
+      migrate_data: true,
+      remove_source_columns: true
+    })
+    Spina::Line.create_translation_table!({
+      content: :string
+    }, {
+      migrate_data: true,
+      remove_source_columns: true
+    })
   end
 
   def down
-    Spina::Page.drop_translation_table!
-    Spina::Text.drop_translation_table!
-    Spina::Line.drop_translation_table!
+    Spina::Page.drop_translation_table! migrate_data: true
+    Spina::Text.drop_translation_table! migrate_data: true
+    Spina::Line.drop_translation_table! migrate_data: true
   end
 end

--- a/test/dummy/db/migrate/20160421084455_create_spina_translation_tables.spina.rb
+++ b/test/dummy/db/migrate/20160421084455_create_spina_translation_tables.spina.rb
@@ -1,14 +1,33 @@
 # This migration comes from spina (originally 2)
 class CreateSpinaTranslationTables < ActiveRecord::Migration
   def up
-    Spina::Page.create_translation_table! title: :string, menu_title: :string, description: :string, seo_title: :string, materialized_path: :string
-    Spina::Text.create_translation_table! content: :text
-    Spina::Line.create_translation_table! content: :string
+    Spina::Page.create_translation_table!({
+      title: :string,
+      menu_title: :string,
+      description: :string,
+      seo_title: :string,
+      materialized_path: :string
+    }, {
+      migrate_data: true,
+      remove_source_columns: true
+    })
+    Spina::Text.create_translation_table!({
+      content: :text
+    }, {
+      migrate_data: true,
+      remove_source_columns: true
+    })
+    Spina::Line.create_translation_table!({
+      content: :string
+    }, {
+      migrate_data: true,
+      remove_source_columns: true
+    })
   end
 
   def down
-    Spina::Page.drop_translation_table!
-    Spina::Text.drop_translation_table!
-    Spina::Line.drop_translation_table!
+    Spina::Page.drop_translation_table! migrate_data: true
+    Spina::Text.drop_translation_table! migrate_data: true
+    Spina::Line.drop_translation_table! migrate_data: true
   end
 end


### PR DESCRIPTION
I simply updated translations tables migrations and let globalize gem automatically migrate data and remove source columns  😉 

Regards

