### PR TITLE
Update structure items add_fields class and method name

### DIFF
--- a/app/assets/javascripts/spina/admin/pages.coffee.erb
+++ b/app/assets/javascripts/spina/admin/pages.coffee.erb
@@ -31,7 +31,7 @@ show_page_parts = (page_parts) ->
     $('.horizontal-form-group.page-part[data-name=' + page_part + ']').show()
 
 # Dynamically add and remove fields in a nested form
-$(document).on 'click', 'form .add_fields', (event) ->
+$(document).on 'click', 'form .add_structure_item_fields', (event) ->
   time = new Date().getTime()
   regexp = new RegExp($(this).data('id'), 'g')
   $(this).before($(this).data('fields').replace(regexp, time))
@@ -60,7 +60,7 @@ $(document).on 'click', 'form .add_structure', (event) ->
 
   event.preventDefault()
 
-$(document).on 'click', 'form .remove-structure-item-fields', (event) ->
+$(document).on 'click', 'form .remove_structure_item_fields', (event) ->
   $(this).prev('input[type=hidden]').val('1')
   $pane = $(this).closest('.structure-form-pane')
   $link = $("a[href='##{$pane.attr('id')}']").parents('li')

--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -51,7 +51,7 @@
   margin: 0 auto
   max-width: 960px
   @include display(flex)
-  
+
 .sidebar-form-content
   @include flex(1)
 
@@ -306,7 +306,7 @@
 
   #{$all-text-inputs}, .text-input, .select-dropdown
     @include flex(1)
-    
+
     &:not(:first-child)
       border-bottom-left-radius: 0
       border-top-left-radius: 0
@@ -445,7 +445,7 @@ fieldset
     &:hover .restaurant-dish-price .remove_fields
       opacity: 1
 
-  .add_fields.button
+  .add_structure_item_fields.button
     background: #f5f5f5
     font-size: 13px
     font-weight: 600

--- a/app/helpers/spina/admin/pages_helper.rb
+++ b/app/helpers/spina/admin/pages_helper.rb
@@ -1,20 +1,20 @@
 module Spina
   module Admin
     module PagesHelper
-      def link_to_add_fields(f, association, &block)
+      def link_to_add_structure_item_fields(f, association, &block)
         new_object = f.object.send(association).klass.new
         id = new_object.object_id
         fields = f.fields_for(association, new_object, child_index: id) do |builder|
           build_structure_parts(f.object.page_part.name, new_object) if structure_item?(new_object)
           render("spina/admin/#{ partable_partial_namespace(new_object) }/fields", f: builder)
         end
-        link_to '#', class: "#{add_fields_class(new_object)} button button-link", data: {id: id, fields: fields.gsub("\n", "")} do
+        link_to '#', class: "#{add_structure_item_fields_class(new_object)} button button-link", data: {id: id, fields: fields.gsub("\n", "")} do
           block.yield
         end
       end
 
-      def add_fields_class(object)
-        structure_item?(object) ? 'add_structure' : 'add_fields'
+      def add_structure_item_fields_class(object)
+        structure_item?(object) ? 'add_structure' : 'add_structure_item_fields'
       end
 
       def structure_item?(object)

--- a/app/helpers/spina/application_helper.rb
+++ b/app/helpers/spina/application_helper.rb
@@ -21,13 +21,13 @@ module Spina
       end
     end
 
-    def link_to_add_fields(name, f, association)
+    def link_to_add_structure_item_fields(name, f, association)
       new_object = f.object.send(association).klass.new
       id = new_object.object_id
       fields = f.fields_for(association, new_object, child_index: id) do |builder|
         render(association.to_s.singularize + "_fields", f: builder)
       end
-      link_to(name, '#', class: "add_fields button button-primary button-link", data: {id: id, fields: fields.gsub("\n", ""), icon: '&'})
+      link_to(name, '#', class: "add_structure_item_fields button button-primary button-link", data: {id: id, fields: fields.gsub("\n", ""), icon: '&'})
     end
 
     def current_account

--- a/app/views/spina/admin/page_partables/structures/_form.html.haml
+++ b/app/views/spina/admin/page_partables/structures/_form.html.haml
@@ -13,7 +13,7 @@
 
       = f.fields_for :page_partable do |ff|
         - ff.object.page_part = f.object
-        = link_to_add_fields ff, :structure_items do
+        = link_to_add_structure_item_fields ff, :structure_items do
           = icon('plus')
 
     .structure-form-content

--- a/app/views/spina/admin/structure_items/_fields.html.haml
+++ b/app/views/spina/admin/structure_items/_fields.html.haml
@@ -12,5 +12,4 @@
       = render "spina/admin/structure_partables/#{ partable_type_partial_namespace(ff.object.structure_partable_type) }/form", f: ff
 
   = f.hidden_field :_destroy
-  = link_to t('spina.delete'), '#', class: 'remove-structure-item-fields button button-mini button-link pull-right'
-
+  = link_to t('spina.delete'), '#', class: 'remove_structure_item_fields button button-mini button-link pull-right'


### PR DESCRIPTION
The way Spina adds nested attributes with structure items is very specific and the current code clashes with 3rd party gems such as `Cacoon` which is nice to add to plugins for more standard nested form associations.