### PR TITLE
Move order of carrierwave S3 storage inside init file

### DIFF
--- a/lib/generators/spina/templates/config/initializers/carrierwave.rb
+++ b/lib/generators/spina/templates/config/initializers/carrierwave.rb
@@ -2,13 +2,13 @@ CarrierWave.configure do |config|
   config.storage = :file
 
   # Use S3 if you want
-  # config.storage = :fog
   # config.fog_credentials = {
   #   provider:               'AWS',
   #   region:                 '',
   #   aws_access_key_id:      '',
   #   aws_secret_access_key:  ''
   # }
+  # config.storage = :fog
   # config.fog_directory  = ''
   # config.fog_public     = true
   # config.fog_attributes = { 'Cache-Control' => 'max-age=315576000' }

--- a/test/dummy/config/initializers/carrierwave.rb
+++ b/test/dummy/config/initializers/carrierwave.rb
@@ -2,13 +2,13 @@ CarrierWave.configure do |config|
   config.storage = :file
 
   # Use S3 if you want
-  # config.storage = :fog
   # config.fog_credentials = {
   #   provider:               'AWS',
   #   region:                 '',
   #   aws_access_key_id:      '',
   #   aws_secret_access_key:  ''
   # }
+  # config.storage = :fog
   # config.fog_directory  = ''
   # config.fog_public     = true
   # config.fog_attributes = { 'Cache-Control' => 'max-age=315576000' }


### PR DESCRIPTION
The latest version of carrierwave requires you to specfic the storage
after the credentials. Fixes #209 