### PR TITLE
Fix clearing issue of add image button

### DIFF
--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -51,7 +51,7 @@
   margin: 0 auto
   max-width: 960px
   @include display(flex)
-  
+
 .sidebar-form-content
   @include flex(1)
 
@@ -306,7 +306,7 @@
 
   #{$all-text-inputs}, .text-input, .select-dropdown
     @include flex(1)
-    
+
     &:not(:first-child)
       border-bottom-left-radius: 0
       border-top-left-radius: 0
@@ -814,6 +814,7 @@ input.datepicker
   display: block
   margin-top: 2px
   position: relative
+  text-align: right
 
   .image
     @include transition(all .3s ease)
@@ -842,8 +843,6 @@ input.datepicker
     font-weight: 600
     line-height: 36px
     margin-bottom: 2px
-    position: absolute
-    right: 0px
 
     span
       border: 5px solid #fff

--- a/app/views/spina/admin/page_partables/attachment_collections/_form.html.haml
+++ b/app/views/spina/admin/page_partables/attachment_collections/_form.html.haml
@@ -3,7 +3,7 @@
 .horizontal-form-content
   = f.fields_for :page_partable, f.object.page_partable do |ff|
     = link_to select_collection_admin_attachments_path(ff.object_name, selected_attachment_ids: ff.object.attachment_ids), remote: true, class: 'media_picker clearfix' do
-      .placeholder.pull-right
+      .placeholder
         %span.button.button-small.button-round
           %i.icon.icon-dots
           = t('spina.choose_from_library')

--- a/app/views/spina/admin/page_partables/attachments/_form.html.haml
+++ b/app/views/spina/admin/page_partables/attachments/_form.html.haml
@@ -2,7 +2,7 @@
   = f.object.title
 .horizontal-form-content
   = link_to select_admin_attachments_path(f.object_name, selected_attachment_id: f.object.page_partable.try(:id)), remote: true, class: 'media_picker clearfix' do
-    .placeholder.pull-right
+    .placeholder
       %span.button.button-small.button-round
         %i.icon.icon-dots
         = t('spina.choose_from_library')

--- a/app/views/spina/admin/page_partables/photo_collections/_form.html.haml
+++ b/app/views/spina/admin/page_partables/photo_collections/_form.html.haml
@@ -3,7 +3,7 @@
 .horizontal-form-content
   = f.fields_for :page_partable, f.object.page_partable do |ff|
     = link_to spina.photo_collection_select_admin_photos_path(ff.object_name, selected_photo_ids: ff.object.photo_ids), remote: true, class: 'media_picker clearfix' do
-      .placeholder.pull-right
+      .placeholder
         %span.button.button-small.button-round
           %i.icon.icon-dots
           =t 'spina.pages.photos_picker'

--- a/app/views/spina/admin/page_partables/photos/_form.html.haml
+++ b/app/views/spina/admin/page_partables/photos/_form.html.haml
@@ -2,7 +2,7 @@
   = f.object.title
 .horizontal-form-content
   = link_to spina.photo_select_admin_photos_path(f.object_name, selected_photo_id: f.object.page_partable.try(:id)), remote: true, class: 'media_picker clearfix' do
-    .placeholder.pull-right
+    .placeholder
       %span.button.button-small.button-round
         %i.icon.icon-dots
         =t 'spina.pages.photo_picker'

--- a/app/views/spina/admin/structure_partables/photos/_form.html.haml
+++ b/app/views/spina/admin/structure_partables/photos/_form.html.haml
@@ -1,5 +1,5 @@
 = link_to spina.photo_select_admin_photos_path(f.object_name, selected_photo_id: f.object.structure_partable.try(:id)), remote: true, class: "media_picker" do
-  .placeholder.pull-right
+  .placeholder
     %span.button.button-small.button-round{data: {icon: 'U'}}=t 'spina.pages.photo_picker'
   - if f.object.structure_partable && f.object.structure_partable.file.present?
     .image


### PR DESCRIPTION
In structures the image button sits over the delete button because of absolute positioning so aligning right with text align on the parent instead