### PR TITLE
Remove nprogress from file upload js

### DIFF
--- a/app/assets/javascripts/spina/admin/uploads.coffee
+++ b/app/assets/javascripts/spina/admin/uploads.coffee
@@ -9,17 +9,12 @@ $.fn.uploadPhoto = ->
       types = /(\.|\/)(gif|jpe?g|png)$/i
       file = data.files[0]
       if types.test(file.type) || types.test(file.name)
-        NProgress.start()
         $(this).find('.customfile').addClass('loading')
         data.submit()
       else
         alert("#{file.name} is geen gif-, jpeg- of png-bestand")
-    progress: (e, data) ->
-      if data.context
-        NProgress.set(data.loaded / data.total)
     done: (e, data) ->
       $(this).find('.customfile').removeClass('loading')
-      NProgress.done()
 
 # Upload document
 $.fn.uploadDocument = ->
@@ -32,14 +27,9 @@ $.fn.uploadDocument = ->
       types = /(\.|\/)(pdf|docx?|rtf|txt)$/i
       file = data.files[0]
       if types.test(file.type) || types.test(file.name)
-        NProgress.start()
         $(this).find('.customfile').addClass('loading')
         data.submit()
       else
         alert("#{file.name} is geen pdf-, word-, txt- of rtf-bestand")
-    progress: (e, data) ->
-      if data.context
-        NProgress.set(data.loaded / data.total)
     done: (e, data) ->
       $(this).find('.customfile').removeClass('loading')
-      NProgress.done()


### PR DESCRIPTION
Removal of `NProgress` in commit https://github.com/denkGroot/Spina/commit/88c78cc1714db5011f5a1ef33726a0f867c371d4 caused the file upload to break.