### PR TITLE
Remove legacy grid sass import

### DIFF
--- a/app/assets/stylesheets/spina/_admin_editing.sass
+++ b/app/assets/stylesheets/spina/_admin_editing.sass
@@ -8,9 +8,6 @@
 @import bourbon
 @import neat
 
-// Grid
-@import grid
-
 // Fonts
 @import fonts
 


### PR DESCRIPTION
Missed this from the last commit