### PR TITLE
Set dateFormat for datepicker and firstDay

### DIFF
--- a/app/assets/javascripts/spina/admin/application.coffee.erb
+++ b/app/assets/javascripts/spina/admin/application.coffee.erb
@@ -147,6 +147,8 @@ ready = ->
 
   # Datepicker
   if $('.datepicker').length > 0
-    $('.datepicker').datepicker()
+    $('.datepicker').datepicker
+      dateFormat: "dd-mm-yy"
+      firstDay: 1
 
 $(document).on 'turbolinks:load', ready


### PR DESCRIPTION
This commit(https://github.com/denkGroot/Spina/commit/48e89e6652c22c047703ea08c3e3020f0078ae06) removed the `dateFormat` so the datepicker is currently broken in my articles plugin and probably anywhere else its being used. This PR just puts this back as well as setting the startDay to Monday 👍 