### PR TITLE
fix error `cannot update a new record` 

### DIFF
--- a/app/models/spina/account.rb
+++ b/app/models/spina/account.rb
@@ -64,7 +64,7 @@ module Spina
       theme.custom_pages.each do |page|
         Page.where(name: page[:name])
             .first_or_create(title: page[:title])
-            .update_columns(view_template: page[:view_template], deletable: page[:deletable])
+            .update_attributes(view_template: page[:view_template], deletable: page[:deletable])
       end
     end
 


### PR DESCRIPTION
Hello!

Great project.

When creating a new theme initializer and switching to it, update_columns gives an error "cannot update a new record." 

This fixed it for me.