### PR TITLE
Add Spina::Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A page in Spina has many Page parts. By default these page parts can be one of t
 - `Spina::Photo`
 - `Spina::PhotoCollection`
 - `Spina::Structure`
+- `Spina::Option`
 
 These are the building blocks of your view templates. You can have an unlimited number of page parts in a page. We prefer to keep the number of parts to a minimum so that managing your pages won't become too complex.
 

--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -522,8 +522,24 @@ input.datepicker
   transition: border .2s ease
   @extend .icon, .icon-caret-down
 
+  label
+    background: #f5f5f5
+    border-right: 1px solid #ddd
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .16)
+    color: #999
+    display: inline-block
+    height: 38px
+    line-height: 38px
+    font-family: $font-family
+    font-size: 13px
+    font-weight: 600
+    margin-right: -4px
+    padding: 0 11px
+
+    &:after
+      content: ":"
+
   &:hover
-    // background: #f5f5f5
     border: 1px solid $primary-color
 
   &:before

--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -26,7 +26,7 @@ module Spina
         if @page.save
           redirect_to spina.edit_admin_page_url(@page)
         else
-          @page_parts = @page.page_parts
+          @page_parts = @page.view_template_page_parts(current_theme).map { |part| @page.page_part(part) }
           render :new, layout: 'spina/admin/admin'
         end
       end
@@ -50,7 +50,7 @@ module Spina
             format.js
           else
             format.html do
-              @page_parts = @page.page_parts
+              @page_parts = @page.view_template_page_parts(current_theme).map { |part| @page.page_part(part) }
               render :edit, layout: 'spina/admin/admin'
             end
           end

--- a/app/helpers/spina/admin/pages_helper.rb
+++ b/app/helpers/spina/admin/pages_helper.rb
@@ -25,11 +25,13 @@ module Spina
         structure = current_theme.structures.find { |structure| structure[:name] == name }
         return item.structure_parts unless structure.present?
         structure[:structure_parts].map do |structure_part|
+          options = structure_part[:options]
           part = item.structure_parts.where(name: structure_part[:name]).first
           if part.nil?
             part = item.structure_parts.build(structure_part)
             part.structure_partable = structure_part[:partable_type].constantize.new
           end
+          part.options = options
           part
         end
       end
@@ -55,6 +57,10 @@ module Spina
           page_menu_title = page.depth.zero? ? page.menu_title : " #{page.menu_title}".indent(page.depth, '-')
           [page_menu_title, page.id]
         end.compact
+      end
+
+      def option_label(part, value)
+        t(['options',part.name,value].compact.join('.'))
       end
 
     end

--- a/app/models/concerns/spina/optionable.rb
+++ b/app/models/concerns/spina/optionable.rb
@@ -1,0 +1,12 @@
+require 'active_support/concern'
+
+module Spina
+  module Optionable
+    extend ActiveSupport::Concern
+
+    included do
+      attr_accessor :options
+    end
+
+  end
+end

--- a/app/models/concerns/spina/partable.rb
+++ b/app/models/concerns/spina/partable.rb
@@ -1,7 +1,9 @@
 module Spina
   module Partable
     def part(part)
+      options = part[:options]
       part = parts.where(name: part[:name]).first || parts.build(part)
+      part.options = options unless part.options
       part.partable = part.partable_type.constantize.new unless part.partable.present?
       part
     end

--- a/app/models/spina/option.rb
+++ b/app/models/spina/option.rb
@@ -1,0 +1,17 @@
+module Spina
+  class Option < ApplicationRecord
+    has_one :page_part, as: :page_partable
+    has_one :layout_part, as: :layout_partable
+    has_one :structure_part, as: :structure_partable
+
+    def content
+      I18n.t(['options',part.name,value].compact.join('.'))
+    end
+
+    private
+
+    def part
+      page_part || layout_part || structure_part
+    end
+  end
+end

--- a/app/models/spina/page_part.rb
+++ b/app/models/spina/page_part.rb
@@ -1,6 +1,7 @@
 module Spina
   class PagePart < ApplicationRecord
     include Part
+    include Optionable
 
     belongs_to :page, inverse_of: :page_parts
     belongs_to :page_partable, polymorphic: true, optional: true

--- a/app/models/spina/structure_part.rb
+++ b/app/models/spina/structure_part.rb
@@ -2,6 +2,7 @@ module Spina
   class StructurePart < ApplicationRecord
     include Part
     include PhotoCollectable
+    include Optionable
 
     belongs_to :structure_item, optional: true
     belongs_to :structure_partable, polymorphic: true, optional: true

--- a/app/views/spina/admin/page_partables/options/_form.html.haml
+++ b/app/views/spina/admin/page_partables/options/_form.html.haml
@@ -1,0 +1,6 @@
+.horizontal-form-label
+  = f.object.title
+.horizontal-form-content
+  = f.fields_for :page_partable, f.object.page_partable do |ff|
+    .select-dropdown
+      = ff.select :value, f.object.options[:values].map{|o| [option_label(f.object, o), o]}, prompt: true

--- a/app/views/spina/admin/structure_partables/options/_form.html.haml
+++ b/app/views/spina/admin/structure_partables/options/_form.html.haml
@@ -1,5 +1,5 @@
 = f.fields_for :structure_partable, f.object.structure_partable do |ff|
-  = ff.label :value, f.object.title
   .select-dropdown
+    = ff.label :value, f.object.title
     = ff.select :value, f.object.options[:values].map{|o| [option_label(f.object, o), o]},
     prompt: true

--- a/app/views/spina/admin/structure_partables/options/_form.html.haml
+++ b/app/views/spina/admin/structure_partables/options/_form.html.haml
@@ -1,0 +1,5 @@
+= f.fields_for :structure_partable, f.object.structure_partable do |ff|
+  = ff.label :value, f.object.title
+  .select-dropdown
+    = ff.select :value, f.object.options[:values].map{|o| [option_label(f.object, o), o]},
+    prompt: true

--- a/db/migrate/6_create_spina_options.rb
+++ b/db/migrate/6_create_spina_options.rb
@@ -1,0 +1,8 @@
+class CreateSpinaOptions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :spina_options do |t|
+      t.string :value
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/config/initializers/themes/demo.rb
+++ b/test/dummy/config/initializers/themes/demo.rb
@@ -31,6 +31,12 @@
     name:           'structure',
     title:          'Structure',
     partable_type:  'Spina::Structure'
+  }, {
+    name:           'option',
+    title:          'Option',
+    partable_type:  'Spina::Option',
+    options: {
+      values: ['val1', 'val2']
   }]
 
   theme.structures = [{
@@ -43,6 +49,13 @@
       name:           'description',
       title:          'Description',
       partable_type:  'Spina::Text'
+    }, {
+      name:           'alignment',
+      title:          'Alignment',
+      partable_type:  'Spina::Option',
+      options: {
+        values: ['left', 'right', 'center']
+      }
     }]
   }]
 
@@ -65,7 +78,7 @@
     name: 'demo',
     title: 'Demo',
     description: 'Contains examples of every page part',
-    page_parts: ['line', 'text', 'photo', 'photo_collection', 'attachment', 'attachment_collection', 'structure']
+    page_parts: ['line', 'text', 'photo', 'photo_collection', 'attachment', 'attachment_collection', 'option', 'structure']
   }]
 
   theme.custom_pages = [{

--- a/test/dummy/config/initializers/themes/demo.rb
+++ b/test/dummy/config/initializers/themes/demo.rb
@@ -37,6 +37,7 @@
     partable_type:  'Spina::Option',
     options: {
       values: ['val1', 'val2']
+    }
   }]
 
   theme.structures = [{

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 5) do
+ActiveRecord::Schema.define(version: 20170507153143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,12 @@ ActiveRecord::Schema.define(version: 5) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["name"], name: "index_spina_navigations_on_name", unique: true, using: :btree
+  end
+
+  create_table "spina_options", force: :cascade do |t|
+    t.string   "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "spina_page_parts", force: :cascade do |t|

--- a/test/models/spina/option_test.rb
+++ b/test/models/spina/option_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+module Spina
+  class OptionTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
`Spina::Option` type, usable in both structures and pages.

Example config would be as follows:

```
::Spina::Theme.register do |theme|

  theme.name = 'default'
  theme.title = 'Default Theme'

  theme.page_parts = [{
    name:           'text',
    title:          'Text',
    partable_type:  'Spina::Text'
  },{
    name: 'option',
    title: 'Option 1',
    partable_type: 'Spina::Option',
    options: {
      values: ['val1', 'val2']
    }
  },{
    name: 'structure',
    title: 'Structure 1',
    partable_type: 'Spina::Structure'
  }]

  theme.structures = [{
    name: 'structure',
    structure_parts: [{
      name: 'title',
      title: 'Title',
      partable_type: 'Spina::Line'
    },{
      name: 'text',
      title: 'Text',
      partable_type: 'Spina::Text'
    },{
      name: 'alignment',
      title: 'Alignment',
      partable_type: 'Spina::Option',
      options: {
        values: ['left', 'right', 'centre']
      }
    }]
  }]

  theme.view_templates = [{
    name:       'homepage',
    title:      'Homepage',
    page_parts: ['text']
  }, {
    name: 'show',
    title:        'Default',
    description:  'A simple page',
    usage:        'Use for your content',
    page_parts:   ['text', 'option', 'structure']
  }]

  theme.custom_pages = [{
    name:           'homepage',
    title:          'Homepage',
    deletable:      false,
    view_template:  'homepage'
  }]

  theme.navigations = [{
    name: 'mobile',
    label: 'Mobile'
  }, {
    name: 'main',
    label: 'Main navigation',
    auto_add_pages: true
  }]

end
```