### PR TITLE
Override 115% width for structure selects

### DIFF
--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -688,6 +688,10 @@ input.datepicker
   .structure-form-part
     padding: 5px 0
 
+    .select-dropdown
+      select
+        width: auto
+
 // Custom file input
 
 .new_document


### PR DESCRIPTION
This fixes the select so that it doesn't drop down to the line below the label