### PR TITLE
Allow Navigations to have a link CSS class

### DIFF
--- a/app/presenters/spina/pages/menu_presenter.rb
+++ b/app/presenters/spina/pages/menu_presenter.rb
@@ -10,12 +10,13 @@ module Spina
       include ActionView::Helpers::UrlHelper
       include ActiveSupport::Configurable
 
-      config_accessor :list_tag, :list_class, :li, :list_wrapper, :list_item_tag, :list_item_css, :selected_css, :current_css, :first_css, :last_css, :list_tag_with_child_css, :list_item_with_child_css
+      config_accessor :list_tag, :list_class, :li, :list_wrapper, :list_item_tag, :list_item_css, :selected_css, :current_css, :first_css, :last_css, :list_tag_with_child_css, :list_item_with_child_css, :list_item_link_css
 
       self.list_tag = :ul
       self.list_class = 'nav'
       self.list_item_tag = :li
       self.list_item_css = nil
+      self.list_item_link_css = nil
       self.list_wrapper = false
       self.selected_css = 'active'
       self.current_css = 'current'
@@ -63,7 +64,7 @@ module Spina
       def render_menu_item(menu_item, index, menu_items_length)
         content_tag(list_item_tag, class: menu_item_css(menu_item[0], index, menu_items_length, !menu_item[1].empty?)) do
           buffer = ActiveSupport::SafeBuffer.new
-          buffer << link_to(menu_item[0].menu_title, menu_item[0].full_materialized_path)
+          buffer << link_to(menu_item[0].menu_title, menu_item[0].full_materialized_path, class: list_item_link_css)
           buffer << render_list_wrapper(menu_item[1])
           buffer
         end


### PR DESCRIPTION
I've been using Bootstrap 4 to build a Spina CMS site, and I can't provide a link class to the `MenuPresenter`. This gives me an unstyled menu which looks a bit weird. I could probably fix this with some CSS Mixins, but I think this is probably a useful feature to have.

You can now set menu link item CSS:

```
- menu = Spina::Pages::MenuPresenter.new(pages.in_menu.arrange(order: :position), self, @page)
- menu.list_class = 'navbar-nav'
- menu.list_item_css = 'nav-item'
- menu.list_item_link_css = 'nav-link'
```

And the HTML is rendered accordingly:

```
<ul class="navbar-nav">
  <li class="nav-item first">
    <a class="nav-link" href="/contact">Contact us</a>
  </li>
  <li class="nav-item">
    <a class="nav-link" href="/about">About us</a>
  </li>
</ul>
```
