### PR TITLE
Add main rails app helpers to Spina::ApplicationController

### DIFF
--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -23,6 +23,8 @@ module Spina
     config.to_prepare do
       [Rails.root].flatten.map { |p| Dir[p.join('app', 'decorators', '**', '*_decorator.rb')]}.flatten.uniq.each do |decorator|
         Rails.configuration.cache_classes ? require(decorator) : load(decorator)
+
+      Spina::ApplicationController.helper Rails.application.helpers
       end
     end
 


### PR DESCRIPTION
Allows helpers defined by the main rails app to be used in views overridden from Spina.