### PR TITLE
Refactor part content into the Partable concern

### DIFF
--- a/app/models/concerns/spina/partable.rb
+++ b/app/models/concerns/spina/partable.rb
@@ -12,6 +12,16 @@ module Spina
         end
         part
       end
+
+      def has_content?(name)
+        content(name).present?
+      end
+
+      def content(name)
+        part = parts.find_by(name: name)
+        part.try(:content)
+      end
+
     end
   end
 end

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -59,15 +59,6 @@ module Spina
       read_attribute(:seo_title).blank? ? title : read_attribute(:seo_title)
     end
 
-    def has_content?(page_part)
-      content(page_part).present?
-    end
-
-    def content(page_part)
-      page_part = page_parts.where(name: page_part).first
-      page_part.try(:content)
-    end
-
     def live?
       !draft? && active?
     end

--- a/app/models/spina/structure_item.rb
+++ b/app/models/spina/structure_item.rb
@@ -13,14 +13,6 @@ module Spina
 
     alias_attribute :parts, :structure_parts
 
-    def has_content?(options)
-      content(options).present?
-    end
-
-    def content(options)
-      part(options).try(:content)
-    end
-
     def ensure_position
       self.position ||= Time.now.to_i
     end


### PR DESCRIPTION
This PR moves `content()` and `has_content?()` into the `Partable` concern and uses the `parts` attribute alias to get content based on the name provided.