### PR TITLE
Amazon AWS s3

### DIFF
--- a/app/uploaders/spina/default_store_uploader.rb
+++ b/app/uploaders/spina/default_store_uploader.rb
@@ -1,7 +1,7 @@
 module Spina
   class DefaultStoreUploader < CarrierWave::Uploader::Base
 
-    storage :fog
+    storage :fog if Spina.config.storage == :s3
 
     def store_dir
       case ::Spina.config.storage

--- a/app/uploaders/spina/default_store_uploader.rb
+++ b/app/uploaders/spina/default_store_uploader.rb
@@ -1,6 +1,8 @@
 module Spina
   class DefaultStoreUploader < CarrierWave::Uploader::Base
 
+    storage :fog
+
     def store_dir
       case ::Spina.config.storage
       when :s3

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "0.12.0"
+  VERSION = "0.12.1"
 end


### PR DESCRIPTION
To get spina to upload to S3 I added Fog/AWS  and had to update the default uploader

Is this needed? It is the only way it would work for me

 class DefaultStoreUploader < CarrierWave::Uploader::Base
storage :fog if Spina.config.storage == :s3