### PR TITLE
Fix loading spinner for attachment uploads

### DIFF
--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -742,8 +742,12 @@ input.datepicker
       @extend .icon, .icon-refresh:before
       display: none
       font-size: 36px
+      height: 50px
+      width: 36px
 
   .customfile.loading
+    padding: 7px 0
+
     &:before
       display: none
 


### PR DESCRIPTION
Had to add a fixed height and width otherwise the whole element was
spinning within the table row at 100% width

### Before
![attachment-upload](https://user-images.githubusercontent.com/3071606/31054117-8cb40874-a6a3-11e7-9e52-be658ba9115a.gif)


### After
![attachment-upload](https://user-images.githubusercontent.com/3071606/31054112-7794c91a-a6a3-11e7-8ca1-655ab409eb36.gif)
