### PR TITLE
Re-style attachment select and change sort order

### DIFF
--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -776,6 +776,34 @@ input.datepicker
   .customfile-button
     display: none
 
+.document-select
+  ul
+    margin: -20px -20px 20px -20px
+
+  .item
+    border-top: 1px solid #efefef
+    cursor: pointer
+    line-height: 1
+    margin: 0
+    position: relative
+    width: 100%
+
+    label
+      display: block
+      font-size: 0.875rem
+      margin: 0
+      padding: 20px
+
+    input[type="checkbox"],
+    input[type="radio"]
+      left: 0
+      opacity: 0
+      position: absolute
+      top: 0
+
+      &:checked + label
+        background: #f5f5fa
+
 .media_picker
   background: #f9f9f9
   border: 1px solid #d5d5d5

--- a/app/models/spina/attachment.rb
+++ b/app/models/spina/attachment.rb
@@ -6,7 +6,7 @@ module Spina
 
     attr_accessor :_destroy
 
-    scope :sorted, -> { order('created_at DESC') }
+    scope :sorted, -> { order('file ASC') }
     scope :file_attached, -> { where('file IS NOT NULL') }
 
     mount_uploader :file, FileUploader

--- a/app/views/spina/admin/attachments/_select.html.haml
+++ b/app/views/spina/admin/attachments/_select.html.haml
@@ -4,22 +4,12 @@
     %h3= t('spina.attachments.insert')
 
   %section
-    -# = form_for [spina, :admin, @attachment], html: {multipart: true} do |f|
-    -#   = f.file_field :file, data: {customfileinput: true}
-
-    = form_tag spina.insert_admin_attachments_path(params[:page_part_id]), remote: true, class: 'gallery-prepend-attachment', style: 'margin-bottom: 0' do
-      .table-container
-        %table.table.table-clickable
-          %thead
-            %tr
-              %th
-              %th= Spina::Attachment.human_attribute_name(:name)
-          %tbody
-            - @attachments.each do |attachment|
-              %tr
-                %td= radio_button_tag :attachment_id, attachment.id, attachment.id == @selected_attachment_id
-                %td= attachment.name
-
+    = form_tag spina.insert_admin_attachments_path(params[:page_part_id]), remote: true, class: 'document-select' do
+      %ul
+        - @attachments.each do |attachment|
+          %li.item
+            = radio_button_tag :attachment_id, attachment.id, attachment.id == @selected_attachment_id
+            = label_tag "attachment_id_#{attachment.id}", attachment.name
       %footer
         = link_to t('spina.cancel'), "#", data: {dismiss: 'modal'}
         = button_tag t('spina.attachments.insert'), type: 'submit', class: 'primary', data: {icon: 't '}

--- a/app/views/spina/admin/attachments/_select_collection.html.haml
+++ b/app/views/spina/admin/attachments/_select_collection.html.haml
@@ -4,22 +4,12 @@
     %h3= t('spina.attachments.insert_multiple')
 
   %section
-    -# = form_for [spina, :admin, @attachment], html: {multipart: true} do |f|
-    -#   = f.file_field :file, data: {customfileinput: true}
-
-    = form_tag spina.insert_collection_admin_attachments_path(params[:page_part_id]), remote: true, class: 'gallery-prepend-attachment', style: 'margin-bottom: 0' do
-      .table-container
-        %table.table.table-clickable
-          %thead
-            %tr
-              %th
-              %th= Spina::Attachment.human_attribute_name(:name)
-          %tbody
-            - @attachments.each do |attachment|
-              %tr
-                %td= check_box_tag 'attachment_ids[]', attachment.id, attachment.id.in?(@selected_attachment_ids)
-                %td= attachment.name
-
+    = form_tag spina.insert_collection_admin_attachments_path(params[:page_part_id]), remote: true, class: 'document-select' do
+      %ul
+        - @attachments.each do |attachment|
+          %li.item
+            = check_box_tag 'attachment_ids[]', attachment.id, attachment.id.in?(@selected_attachment_ids), id: "attachment_id_#{attachment.id}"
+            = label_tag "attachment_id_#{attachment.id}", attachment.name
       %footer
         = link_to t('spina.cancel'), "#", data: {dismiss: 'modal'}
         = button_tag t('spina.attachments.insert_multiple'), type: 'submit', class: 'primary', data: {icon: 't '}


### PR DESCRIPTION
I felt the table was overkill for a simple list, no JS is required for highlighting chosen documents as I used the `:checked` attribute of the input element.

## Attachment
![attachment-select-single](https://user-images.githubusercontent.com/3071606/31058452-9559212e-a6eb-11e7-95b5-454297abb1eb.gif)

## AttachmentCollection
![attachment-select](https://user-images.githubusercontent.com/3071606/31058453-9559d150-a6eb-11e7-9746-5cd5ab94f45d.gif)
