### PR TITLE
Fix attachments when adding to page templates

### DIFF
--- a/app/models/spina/attachment.rb
+++ b/app/models/spina/attachment.rb
@@ -15,6 +15,10 @@ module Spina
       file.file.try(:filename)
     end
 
+    def content
+      self
+    end
+
     alias_method :old_update_attributes, :update_attributes
     def update_attributes(attributes)
       if attributes["_destroy"] == "1" && attributes["file"].blank?

--- a/app/models/spina/attachment_collection.rb
+++ b/app/models/spina/attachment_collection.rb
@@ -4,8 +4,12 @@ module Spina
     has_one :page_part, as: :page_partable
     has_and_belongs_to_many :attachments, join_table: 'spina_attachment_collections_attachments'
 
-    attr_reader :attachment_tokens    
+    attr_reader :attachment_tokens
     accepts_nested_attributes_for :attachments, allow_destroy: true
+
+    def content
+      self
+    end
 
     def attachment_tokens=(ids)
       self.attachment_ids = ids.split(",")


### PR DESCRIPTION
When adding `@page.content(:attachment).file_url` to a page template it would return undefined method for `file_url` so this change fixes that 👍 