### PR TITLE
add fog_provider to carrierwave template

### DIFF
--- a/lib/generators/spina/templates/config/initializers/carrierwave.rb
+++ b/lib/generators/spina/templates/config/initializers/carrierwave.rb
@@ -2,6 +2,7 @@ CarrierWave.configure do |config|
   config.storage = :file
 
   # Use S3 if you want
+  # config.fog_provider = 'fog/aws'
   # config.fog_credentials = {
   #   provider:               'AWS',
   #   region:                 '',


### PR DESCRIPTION
when not including the config.fog_provider = 'fog/aws' starting the Rails application will result in the error

.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292:in `require': cannot load such file -- fog (LoadError)